### PR TITLE
Increase robustness of order placements

### DIFF
--- a/src/phx/strategy/random/start.sh
+++ b/src/phx/strategy/random/start.sh
@@ -6,4 +6,4 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 source "$ROOT"/../../../opt/conda/bin/activate dev
 
 export PYTHONPATH="$ROOT"/../../:"$PYTHONPATH"
-cd "$ROOT"/random || (echo "Wrong path!" && exit); python3 main.py
+cd "$ROOT"/random || (echo "Wrong path!" && exit); python main.py


### PR DESCRIPTION
1.  Improve quality of logging in the generic callback function by printing out the string representation of objects instead of the python objects themselves. 
2. Avoid self-taking orders. Market orders are buy orders for one symbol, whereas limit orders are sell orders for another symbol. 